### PR TITLE
feat: process unsubs from postmark

### DIFF
--- a/apps/course-builder-web/.env.example
+++ b/apps/course-builder-web/.env.example
@@ -27,6 +27,7 @@ NEXT_PUBLIC_URL="SITE_URL"
 
 # Postmark
 POSTMARK_API_KEY="sk_xxx"
+POSTMARK_WEBHOOK_SECRET="whs_xxx"
 
 # OpenAI Credentials to access gpt-4
 OPENAI_API_KEY="sk_xxx"

--- a/apps/course-builder-web/package.json
+++ b/apps/course-builder-web/package.json
@@ -89,7 +89,7 @@
     "framer-motion": "^10.16.5",
     "groq": "^3.18.1",
     "i": "^0.3.7",
-    "inngest": "^3.3.0",
+    "inngest": "^3.7.0",
     "intl-segmenter-polyfill": "^0.4.4",
     "json-schema": "^0.4.0",
     "liquidjs": "^10.9.4",

--- a/apps/course-builder-web/src/app/api/postmark/webhook/route.ts
+++ b/apps/course-builder-web/src/app/api/postmark/webhook/route.ts
@@ -1,0 +1,26 @@
+import {type NextRequest, type NextResponse} from 'next/server'
+import {inngest} from '@/inngest/inngest.server'
+import {POSTMARK_WEBHOOK_EVENT} from '@/inngest/events/postmark-webhook'
+
+export async function POST(req: NextRequest, res: NextResponse) {
+  const body = await req.json()
+
+  if (
+    req.headers.get('course-builder') !== process.env.POSTMARK_WEBHOOK_SECRET
+  ) {
+    return new Response('ok', {
+      status: 200,
+    })
+  }
+
+  await inngest.send({
+    name: POSTMARK_WEBHOOK_EVENT,
+    data: {
+      ...body,
+    },
+  })
+
+  return new Response('ok', {
+    status: 200,
+  })
+}

--- a/apps/course-builder-web/src/app/test/page.tsx
+++ b/apps/course-builder-web/src/app/test/page.tsx
@@ -12,6 +12,7 @@ import {
   CardFooter,
 } from '@coursebuilder/ui'
 import {Button} from '@coursebuilder/ui'
+import Image from 'next/image'
 
 export default function Component() {
   return (
@@ -138,7 +139,7 @@ export default function Component() {
                     </CardHeader>
                     <CardContent>
                       <p>Views: 1200</p>
-                      <img
+                      <Image
                         alt="Graph for Tip 2"
                         className="object-cover"
                         height="50"
@@ -159,7 +160,7 @@ export default function Component() {
                     </CardHeader>
                     <CardContent>
                       <p>Views: 1500</p>
-                      <img
+                      <Image
                         alt="Graph for Tip 3"
                         className="object-cover"
                         height="50"

--- a/apps/course-builder-web/src/components/lesson-list/list.tsx
+++ b/apps/course-builder-web/src/components/lesson-list/list.tsx
@@ -59,7 +59,7 @@ function useListContext() {
   return listContext
 }
 
-type ItemData = {
+export type ItemData = {
   id: string
   label: string
 }
@@ -402,7 +402,7 @@ export default function LessonList({
         return newState
       })
     },
-    [],
+    [onChange],
   )
 
   const [instanceId] = useState(() => Symbol('instance-id'))

--- a/apps/course-builder-web/src/emails/basic-email.tsx
+++ b/apps/course-builder-web/src/emails/basic-email.tsx
@@ -1,45 +1,37 @@
-import {
-  Body,
-  Container,
-  Head,
-  Html,
-  Preview,
-  Section,
-  Text,
-} from '@react-email/components'
+import {Body, Head, Html, Preview, Section, Link} from '@react-email/components'
 import * as React from 'react'
 import {Markdown} from '@react-email/markdown'
 
-export type WelcomeEmailProps = {
-  user: {
-    name: string
-    email: string
-    id: string
-  }
+export type BasicEmailProps = {
   body: string
+  preview?: string
+  messageType?: 'transactional' | 'broadcast'
 }
 
-export const WelcomeEmail = ({
-  user = {id: '12345', name: 'Carlos', email: 'carlos@example.com'},
+export const BasicEmail = ({
   body = `Hi Joel,\n\nJust catching up on your progress in the Full Stack Foundations module. Good going with the asset links management in your web applications. This lesson is fundamental for enhancing the user experience on nested routes, so it's great to see you moving along.\n\nAs a snapshot:\n- Section: Styling\n- Completed: 'Manage Asset Links in a Remix Application'\n- Module Progress: 7% \n\nRemember, every small technique you master now is adding up to a significant toolkit in full-stack web development.\n\nFor a comprehensive review or for tackling any tricky bits, all past lessons and exercises remain accessible for you.\n\nYour consistency is crucial. Every step forward counts.\n\nKeep going,\nKody the Koala 🐨`,
-}: WelcomeEmailProps) => {
+  preview = ``,
+  messageType = 'broadcast',
+}: BasicEmailProps) => {
   return (
     <Html>
       <Head />
-      <Preview>Build and Sell Your Developer Course</Preview>
+      <Preview>{preview}</Preview>
       <Body style={main}>
         <Section style={content}>
           <Markdown>{body}</Markdown>
         </Section>
         <Section style={footer}>
-          <Markdown>{``}</Markdown>
+          {messageType === 'broadcast' ? (
+            <Link href={`{{{ pm:unsubscribe }}}`}>unsubscribe</Link>
+          ) : null}
         </Section>
       </Body>
     </Html>
   )
 }
 
-export default WelcomeEmail
+export default BasicEmail
 
 const fontFamily = 'HelveticaNeue,Helvetica,Arial,sans-serif'
 

--- a/apps/course-builder-web/src/env.mjs
+++ b/apps/course-builder-web/src/env.mjs
@@ -44,6 +44,7 @@ export const env = createEnv({
     DEEPGRAM_API_KEY: z.string(),
     UPLOADTHING_URL: z.string(),
     POSTMARK_API_KEY: z.string(),
+    POSTMARK_WEBHOOK_SECRET: z.string(),
   },
 
   /**
@@ -85,6 +86,7 @@ export const env = createEnv({
     UPLOADTHING_URL: process.env.UPLOADTHING_URL,
     POSTMARK_API_KEY: process.env.POSTMARK_API_KEY,
     NEXT_PUBLIC_URL: process.env.NEXT_PUBLIC_URL,
+    POSTMARK_WEBHOOK_SECRET: process.env.POSTMARK_WEBHOOK_SECRET,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/apps/course-builder-web/src/inngest/events/postmark-webhook.ts
+++ b/apps/course-builder-web/src/inngest/events/postmark-webhook.ts
@@ -1,0 +1,97 @@
+import {z} from 'zod'
+
+export const POSTMARK_WEBHOOK_EVENT = 'postmark/web-hook-event'
+
+export type PostmarkWebhook = {
+  name: typeof POSTMARK_WEBHOOK_EVENT
+  data: PostmarkWebhookEvent
+}
+
+const PostmarkWebhookEventSchema = z.discriminatedUnion('RecordType', [
+  z.object({
+    RecordType: z.literal('SubscriptionChange'),
+    Recipient: z.string().email(),
+    SuppressionReason: z.enum([
+      z.literal('HardBounce'),
+      z.literal('SpamComplaint'),
+      z.literal('ManualSuppression'),
+    ]),
+    SuppressSending: z.boolean(),
+    MessageID: z.string(),
+    MessageStream: z.string(),
+    Metadata: z.record(z.string()),
+  }),
+  z.object({
+    RecordType: z.literal('Bounce'),
+    Email: z.string().email(),
+    From: z.string().email(),
+    Details: z.string(),
+    Content: z.string(),
+    Description: z.string(),
+    MessageID: z.string(),
+    MessageStream: z.string(),
+    Metadata: z.record(z.string()),
+  }),
+  z.object({
+    RecordType: z.literal('SpamComplaint'),
+    Email: z.string().email(),
+    From: z.string().email(),
+    Details: z.string(),
+    Content: z.string(),
+    Description: z.string(),
+    MessageID: z.string(),
+    MessageStream: z.string(),
+    Metadata: z.record(z.string()),
+  }),
+  z.object({
+    RecordType: z.literal('Open'),
+    Client: z.string(),
+    OS: z.string(),
+    Platform: z.string(),
+    UserAgent: z.string(),
+    ReadSeconds: z.number(),
+    Geo: z.object({
+      CountryISOCode: z.string(),
+      Country: z.string(),
+      RegionISOCode: z.string(),
+      Region: z.string(),
+      City: z.string(),
+      Zip: z.string(),
+      Coords: z.string(),
+    }),
+    MessageID: z.string(),
+    MessageStream: z.string(),
+    Metadata: z.record(z.string()),
+  }),
+  z.object({
+    RecordType: z.literal('Click'),
+    OriginalLink: z.string(),
+    ClickedLink: z.string(),
+    Client: z.string(),
+    OS: z.string(),
+    Platform: z.string(),
+    UserAgent: z.string(),
+    Geo: z.object({
+      CountryISOCode: z.string(),
+      Country: z.string(),
+      RegionISOCode: z.string(),
+      Region: z.string(),
+      City: z.string(),
+      Zip: z.string(),
+      Coords: z.string(),
+    }),
+    MessageID: z.string(),
+    MessageStream: z.string(),
+    Metadata: z.record(z.string()),
+  }),
+  z.object({
+    RecordType: z.literal('Delivery'),
+    Recipient: z.string().email(),
+    Tag: z.string(),
+    MessageID: z.string(),
+    MessageStream: z.string(),
+    Metadata: z.record(z.string()),
+  }),
+])
+
+export type PostmarkWebhookEvent = z.infer<typeof PostmarkWebhookEventSchema>

--- a/apps/course-builder-web/src/inngest/events/postmark-webhook.ts
+++ b/apps/course-builder-web/src/inngest/events/postmark-webhook.ts
@@ -12,9 +12,9 @@ const PostmarkWebhookEventSchema = z.discriminatedUnion('RecordType', [
     RecordType: z.literal('SubscriptionChange'),
     Recipient: z.string().email(),
     SuppressionReason: z.enum([
-      z.literal('HardBounce'),
-      z.literal('SpamComplaint'),
-      z.literal('ManualSuppression'),
+      'HardBounce',
+      'SpamComplaint',
+      'ManualSuppression',
     ]),
     SuppressSending: z.boolean(),
     MessageID: z.string(),

--- a/apps/course-builder-web/src/inngest/functions/notify/creator/user-signup.ts
+++ b/apps/course-builder-web/src/inngest/functions/notify/creator/user-signup.ts
@@ -1,0 +1,66 @@
+import {inngest} from '@/inngest/inngest.server'
+import {USER_CREATED_EVENT} from '@/inngest/events'
+import BasicEmail from '@/emails/basic-email'
+import {sendAnEmail} from '@/utils/send-an-email'
+import {sanityQuery} from '@/server/sanity.server'
+import {Liquid} from 'liquidjs'
+
+export const userSignupAdminEmail = inngest.createFunction(
+  {
+    id: `user-signup-admin-email`,
+    name: 'User Signup Admin Email',
+    idempotency: 'event.user.email',
+  },
+  {
+    event: USER_CREATED_EVENT,
+  },
+  async ({event, step}) => {
+    const email = await step.run(`load email`, async () => {
+      return await sanityQuery<{
+        _id: string
+        subject: string
+        body: string
+        previewText?: string
+      }>(`*[_type == "courseBuilderEmail" && slug.current == "user-signup"][0]`)
+    })
+
+    const parsedEmailBody: string = await step.run(
+      `parse email body`,
+      async () => {
+        try {
+          const engine = new Liquid()
+          return engine.parseAndRender(email.body, {user: event.user})
+        } catch (e: any) {
+          console.error(e.message)
+          return email.body
+        }
+      },
+    )
+
+    const parsedEmailSubject: string = await step.run(
+      `parse email subject`,
+      async () => {
+        try {
+          const engine = new Liquid()
+          return engine.parseAndRender(email.subject, {user: event.user})
+        } catch (e) {
+          return email.subject
+        }
+      },
+    )
+
+    const sendResponse = await step.run('send the email', async () => {
+      return await sendAnEmail({
+        Component: BasicEmail,
+        componentProps: {
+          user: event.user,
+          body: parsedEmailBody,
+        },
+        Subject: parsedEmailSubject,
+        To: 'joel@badass.dev',
+      })
+    })
+
+    return {sendResponse, email, user: event.user}
+  },
+)

--- a/apps/course-builder-web/src/inngest/functions/notify/creator/user-signup.ts
+++ b/apps/course-builder-web/src/inngest/functions/notify/creator/user-signup.ts
@@ -53,7 +53,6 @@ export const userSignupAdminEmail = inngest.createFunction(
       return await sendAnEmail({
         Component: BasicEmail,
         componentProps: {
-          user: event.user,
           body: parsedEmailBody,
         },
         Subject: parsedEmailSubject,

--- a/apps/course-builder-web/src/inngest/functions/notify/creator/weekly-signups.ts
+++ b/apps/course-builder-web/src/inngest/functions/notify/creator/weekly-signups.ts
@@ -3,9 +3,10 @@ import {sendAnEmail} from '@/utils/send-an-email'
 import {sanityQuery} from '@/server/sanity.server'
 import {db} from '@/server/db'
 import {users} from '@/server/db/schema'
-import {sql} from 'drizzle-orm'
+import {gt, sql} from 'drizzle-orm'
 import {Liquid} from 'liquidjs'
 import WeeklySignups from '@/emails/weekly-signups'
+import BasicEmail, {BasicEmailProps} from '@/emails/basic-email'
 
 export const weeklySignupDigest = inngest.createFunction(
   {id: `weekly signup digest`, name: 'Weekly Signup Digest'},
@@ -29,27 +30,61 @@ export const weeklySignupDigest = inngest.createFunction(
           count: sql<number>`cast(count(${users.id}) as UNSIGNED)`,
         })
         .from(users)
+        .where(gt(users.createdAt, sql`DATE_SUB(NOW(), INTERVAL 7 DAY)`))
         .groupBy(users.id)
+
       return result[0]?.count ?? 0
     })
 
-    const parsedEmailBody = await step.run(`parse email`, async () => {
-      const engine = new Liquid()
-      return engine.parseAndRender(email.body, {newUserCount})
-    })
+    const parsedEmailBody: string = await step.run(
+      `parse email body`,
+      async () => {
+        try {
+          const engine = new Liquid()
+          return engine.parseAndRender(email.body, {
+            user: event.user,
+            newUserCount,
+          })
+        } catch (e: any) {
+          console.error(e.message)
+          return email.body
+        }
+      },
+    )
+
+    const parsedEmailSubject: string = await step.run(
+      `parse email subject`,
+      async () => {
+        try {
+          const engine = new Liquid()
+          return engine.parseAndRender(email.subject, {
+            user: event.user,
+            newUserCount,
+          })
+        } catch (e) {
+          return email.subject
+        }
+      },
+    )
 
     const sendResponse = await step.run('send the email', async () => {
-      return await sendAnEmail({
-        Component: WeeklySignups,
+      return await sendAnEmail<BasicEmailProps>({
+        Component: BasicEmail,
         componentProps: {
-          user: event.user,
           body: parsedEmailBody,
+          messageType: 'transactional',
         },
-        Subject: email.subject,
+        Subject: parsedEmailSubject,
         To: `joel@badass.dev`,
       })
     })
 
-    return {sendResponse, email, parsedEmailBody, user: event.user}
+    return {
+      sendResponse,
+      email,
+      parsedEmailBody,
+      parsedEmailSubject,
+      user: event.user,
+    }
   },
 )

--- a/apps/course-builder-web/src/inngest/functions/postmark/postmarks-webhooks-handler.ts
+++ b/apps/course-builder-web/src/inngest/functions/postmark/postmarks-webhooks-handler.ts
@@ -1,0 +1,31 @@
+import {inngest} from '@/inngest/inngest.server'
+import {POSTMARK_WEBHOOK_EVENT} from '@/inngest/events/postmark-webhook'
+
+export const postmarkWebhook = inngest.createFunction(
+  {id: `postmark-webhooks`, name: 'Postmark Unsubscribed Webhooks'},
+  {
+    event: POSTMARK_WEBHOOK_EVENT,
+    if: 'event.data.RecordType in ["Bounce", "SpamComplaint", "SubscriptionChange"]',
+  },
+  async ({event, step}) => {
+    switch (event.data.RecordType) {
+      case 'SubscriptionChange': {
+        if (event.data.SuppressionReason === 'ManualSuppression') {
+          //unsubscribed
+        } else if (!event.data.SuppressSending) {
+          //resubscribed?
+        }
+        break
+      }
+      case 'Bounce': {
+        // something went wrong, display in app message
+        break
+      }
+      case 'SpamComplaint': {
+        // something
+        break
+      }
+    }
+    return event.data
+  },
+)

--- a/apps/course-builder-web/src/inngest/functions/user-created.ts
+++ b/apps/course-builder-web/src/inngest/functions/user-created.ts
@@ -28,7 +28,6 @@ export const userCreated = inngest.createFunction(
       return await sendAnEmail({
         Component: BasicEmail,
         componentProps: {
-          user: event.user,
           body: email.body,
         },
         Subject: email.subject,

--- a/apps/course-builder-web/src/inngest/functions/user-created.ts
+++ b/apps/course-builder-web/src/inngest/functions/user-created.ts
@@ -1,6 +1,6 @@
 import {inngest} from '@/inngest/inngest.server'
 import {USER_CREATED_EVENT} from '@/inngest/events'
-import WelcomeEmail from '@/emails/welcome-email'
+import BasicEmail from '@/emails/basic-email'
 import {sendAnEmail} from '@/utils/send-an-email'
 import {sanityQuery} from '@/server/sanity.server'
 
@@ -26,13 +26,14 @@ export const userCreated = inngest.createFunction(
     })
     const sendResponse = await step.run('send the email', async () => {
       return await sendAnEmail({
-        Component: WelcomeEmail,
+        Component: BasicEmail,
         componentProps: {
           user: event.user,
           body: email.body,
         },
         Subject: email.subject,
         To: event.user.email,
+        type: 'broadcast',
       })
     })
 

--- a/apps/course-builder-web/src/inngest/inngest.config.ts
+++ b/apps/course-builder-web/src/inngest/inngest.config.ts
@@ -10,6 +10,8 @@ import {addSrtToMuxAsset} from '@/inngest/functions/mux/add-srt-to-mux-asset'
 import {tipTitleAndSummaryWriter} from '@/inngest/functions/ai/tip-writer'
 import {userCreated} from '@/inngest/functions/user-created'
 import {weeklySignupDigest} from '@/inngest/functions/notify/creator/weekly-signups'
+import {userSignupAdminEmail} from '@/inngest/functions/notify/creator/user-signup'
+import {postmarkWebhook} from '@/inngest/functions/postmark/postmarks-webhooks-handler'
 
 export const inngestConfig = {
   client: inngest,
@@ -23,5 +25,7 @@ export const inngestConfig = {
     tipTitleAndSummaryWriter,
     userCreated,
     weeklySignupDigest,
+    userSignupAdminEmail,
+    postmarkWebhook,
   ],
 }

--- a/apps/course-builder-web/src/inngest/inngest.server.ts
+++ b/apps/course-builder-web/src/inngest/inngest.server.ts
@@ -33,6 +33,10 @@ import {
   type MUX_SRT_READY_EVENT,
   type MuxSrtReady,
 } from '@/inngest/events/mux-add-srt-to-asset'
+import {
+  POSTMARK_WEBHOOK_EVENT,
+  PostmarkWebhook,
+} from '@/inngest/events/postmark-webhook'
 
 // Create a client to send and receive events
 type Events = {
@@ -46,6 +50,7 @@ type Events = {
   [MUX_SRT_READY_EVENT]: MuxSrtReady
   [AI_TIP_WRITING_REQUESTED_EVENT]: AITipWritingRequested
   [USER_CREATED_EVENT]: UserCreated
+  [POSTMARK_WEBHOOK_EVENT]: PostmarkWebhook
 }
 export const inngest = new Inngest({
   id: 'gpt-4-ai-chains',

--- a/apps/course-builder-web/src/server/auth.ts
+++ b/apps/course-builder-web/src/server/auth.ts
@@ -8,8 +8,7 @@ import GithubProvider from 'next-auth/providers/github'
 
 import {env} from '@/env.mjs'
 import {db} from '@/server/db'
-import {mysqlTable, users} from '@/server/db/schema'
-import {eq} from 'drizzle-orm'
+import {mysqlTable} from '@/server/db/schema'
 import {inngest} from '@/inngest/inngest.server'
 import {USER_CREATED_EVENT} from '@/inngest/events'
 

--- a/apps/course-builder-web/src/utils/send-an-email.ts
+++ b/apps/course-builder-web/src/utils/send-an-email.ts
@@ -7,21 +7,25 @@ export async function sendAnEmail<ComponentPropsType = any>({
   Subject,
   To,
   From = `joel <joel@coursebuilder.dev>`,
+  type = 'transactional',
 }: {
   Component: (props: ComponentPropsType) => React.JSX.Element
   componentProps: ComponentPropsType
   Subject: string
   From?: string
   To: string
+  type?: 'transactional' | 'broadcast'
 }) {
   const emailHtml = render(Component(componentProps))
+
+  const MessageStream = type === 'broadcast' ? 'broadcast' : 'outbound'
 
   const options = {
     From,
     To,
     Subject,
     HtmlBody: emailHtml,
-    MessageStream: `outbound`,
+    MessageStream,
   }
 
   return await fetch(`https://api.postmarkapp.com/email`, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,8 +303,8 @@ importers:
         specifier: ^0.3.7
         version: 0.3.7
       inngest:
-        specifier: ^3.3.0
-        version: 3.6.0(encoding@0.1.13)(typescript@5.2.2)
+        specifier: ^3.7.0
+        version: 3.7.0(encoding@0.1.13)(typescript@5.2.2)
       intl-segmenter-polyfill:
         specifier: ^0.4.4
         version: 0.4.4
@@ -12746,13 +12746,13 @@ packages:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
     dev: false
 
-  /inngest@3.6.0(encoding@0.1.13)(typescript@5.2.2):
-    resolution: {integrity: sha512-l6Vrs1mnj0U64iUpFwNn2CdcieMlNJZyv8ks6NbpQe+xnPJ9P2yoUB4n9NJ891Me2383ozm+PDWc4LcVTu0EAg==}
+  /inngest@3.7.0(encoding@0.1.13)(typescript@5.2.2):
+    resolution: {integrity: sha512-LhtFC3S+Ak1ex94APD4IS6z7EuPrffw0CaIpHnEMNbzbpuVc4bF5aN/N4hS4VjNIx1TGxm6Um4ymHmFCSmtcSg==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.7.2'
     dependencies:
-      buffer: 6.0.3
+      '@types/debug': 4.1.12
       canonicalize: 1.0.8
       chalk: 4.1.2
       cross-fetch: 4.0.0(encoding@0.1.13)
@@ -12764,6 +12764,7 @@ packages:
       serialize-error-cjs: 0.1.3
       strip-ansi: 5.2.0
       type-fest: 3.13.1
+      type-plus: 5.6.0
       typescript: 5.2.2
       zod: 3.22.4
     transitivePeerDependencies:
@@ -19032,6 +19033,14 @@ packages:
       source-map-support: 0.5.21
     dev: false
 
+  /tersify@3.12.1:
+    resolution: {integrity: sha512-VwzXGHZSOB4T27s4uvh9v8FYrNXyfVz0nBQi28TDwrZoQwT8ZJUp1W2Ff73ekN07stJSb0D+pr6iXeNeFqTI6Q==}
+    dependencies:
+      acorn: 8.11.2
+      is-buffer: 2.0.5
+      unpartial: 1.0.5
+    dev: false
+
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -19417,6 +19426,13 @@ packages:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
 
+  /type-plus@5.6.0:
+    resolution: {integrity: sha512-LAIvZzs6mKXYHzwRfGeOuWKsE5jHndwWlLheulMl6eWDSGa1bfZCd0aLQSMgP3HZTbazx/P2UumCqtOz5AMctA==}
+    dependencies:
+      tersify: 3.12.1
+      unpartial: 1.0.5
+    dev: false
+
   /type@1.2.0:
     resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==}
     dev: true
@@ -19717,6 +19733,11 @@ packages:
   /universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+    dev: false
+
+  /unpartial@1.0.5:
+    resolution: {integrity: sha512-yAqaXcachjgZUnM2yIkf+4KJhmyuoj7stBvlnlZpB15OYVbKnLhgJfmLW7qkpzLHCdsm1bEFvhyN9hCmlZ3uuw==}
+    engines: {node: '>=6'}
     dev: false
 
   /untildify@4.0.0:


### PR DESCRIPTION
postmark requires that any non-transactional (broadcast/bulk) emails have an unsubscribe link that **they** manage

this adds that to the Basic email template as well as connecting Postmark webhooks internally to Inngest events

also sketched in the idea of communication preferences that might get removed later